### PR TITLE
Initialise MkDocs documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,3 @@
 # AIA Software Training
 
 Learn the fundamentals of transform-based low-order modelling and analysis
-
-
-## Documentation
-
-The "required global fleet" can be estimated using a very simple model that assumes the number of passengers flying globally annually is known, along with and estimation of the number of seats flown globally per day.
-
-### Constants
-
-| True Constant | Value | Unit |
-| ------------- | ----- | ---- |
-| days per year | $365$ | .    |
-
-| Inputs                       | Value           | Unit        | Source   |
-| ---------------------------- | --------------- | ----------- | -------- |
-| passengers per year          | $5 \times 10^9$ | $year^{-1}$ | ATAG[^1] |
-| seats per aircraft           | $150$           | .           |          |
-| flights per aircraft per day | $2$             | $day^{-1}$  |          |
-
-### Equations
-
-Given that the two sourced inputs that are time dependent are given in different time bases, it is convenient to convert on of these so the two are consistent.
-
-$\text{passengers per day} = \frac{\text{passengers per year}}{\text{days per year}}$
-
-The total required global fleet can then be calculated as a function of this intermediate value and the other inputs.
-
-$\text{required global fleet} = \frac{\text{passengers per day}}{\text{seats per aircraft} \times \text{flights per aircraft per day}}$
-
-[^1]: [ATAG Facts & Figures](https://atag.org/facts-figures)

--- a/docs/aviation.md
+++ b/docs/aviation.md
@@ -1,0 +1,27 @@
+## Aviation
+
+The "required global fleet" can be estimated using a very simple model that assumes the number of passengers flying globally annually is known, along with and estimation of the number of seats flown globally per day.
+
+### Constants
+
+| True Constant | Value | Unit |
+| ------------- | ----- | ---- |
+| days per year | $365$ | .    |
+
+| Inputs                       | Value           | Unit        | Source   |
+| ---------------------------- | --------------- | ----------- | -------- |
+| passengers per year          | $5 \times 10^9$ | $year^{-1}$ | ATAG[^1] |
+| seats per aircraft           | $150$           | .           |          |
+| flights per aircraft per day | $2$             | $day^{-1}$  |          |
+
+### Equations
+
+Given that the two sourced inputs that are time dependent are given in different time bases, it is convenient to convert on of these so the two are consistent.
+
+$\text{passengers per day} = \frac{\text{passengers per year}}{\text{days per year}}$
+
+The total required global fleet can then be calculated as a function of this intermediate value and the other inputs.
+
+$\text{required global fleet} = \frac{\text{passengers per day}}{\text{seats per aircraft} \times \text{flights per aircraft per day}}$
+
+[^1]: [ATAG Facts & Figures](https://atag.org/facts-figures)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Aviation
+
+A simple model of global aviation.
+
+click [here](./aviation.md) to view the model documentation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: Aviation
+theme:
+  name: mkdocs
+
+nav:
+  - index.md
+  - aviation.md


### PR DESCRIPTION
This PR initialises a documentation site using MkDocs. It migrates the documentation previously in README.md into the new MkDocs docs/ directory and splits the documentation between two files, docs/index.md and docs/aviation.md. It also sets up the navigation for the site in mkdocs.yml