### PR TITLE
Add "Developer Guide" section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # AIA Software Training
 
 Learn the fundamentals of transform-based low-order modelling and analysis
+
+## Developer Guide
+
+This repository uses [MkDocs](https://www.mkdocs.org) to generate a static documentation site for users.
+The source files for the site can be found in the [`docs/`](docs) directory and site configuration in [`mkdocs.yml`](mkdocs.yml).
+To serve the site locally, run:
+
+```
+mkdocs serve
+```


### PR DESCRIPTION
This PR adds a "Developer Guide" section to README.md explaining how MkDocs is used for documentation and what the local development workflow is.