### PR TITLE
Improve handling and formatting of maths in documentation

### DIFF
--- a/docs/aviation.md
+++ b/docs/aviation.md
@@ -16,12 +16,22 @@ The "required global fleet" can be estimated using a very simple model that assu
 
 ### Equations
 
-Given that the two sourced inputs that are time dependent are given in different time bases, it is convenient to convert on of these so the two are consistent.
+Given that the two sourced inputs that are time dependent are given in different time bases, it is convenient to convert one of these so the two are consistent, as done in equation $\ref{equation:passengers-per-day}$.
 
-$\text{passengers per day} = \frac{\text{passengers per year}}{\text{days per year}}$
+$$
+\begin{equation}
+\text{passengers per day} = \frac{\text{passengers per year}}{\text{days per year}}
+\label{equation:passengers-per-day}
+\end{equation}
+$$
 
-The total required global fleet can then be calculated as a function of this intermediate value and the other inputs.
+The total required global fleet can then be calculated as a function of this intermediate value and the other inputs, as done in equation $\ref{equation:required-global-fleet}$.
 
-$\text{required global fleet} = \frac{\text{passengers per day}}{\text{seats per aircraft} \times \text{flights per aircraft per day}}$
+$$
+\begin{equation}
+\text{required global fleet} = \frac{\text{passengers per day}}{\text{seats per aircraft} \times \text{flights per aircraft per day}}
+\label{equation:required-global-fleet}
+\end{equation}
+$$
 
 [^1]: [ATAG Facts & Figures](https://atag.org/facts-figures)

--- a/docs/aviation.md
+++ b/docs/aviation.md
@@ -8,11 +8,11 @@ The "required global fleet" can be estimated using a very simple model that assu
 | ------------- | ----- | ---- |
 | days per year | $365$ | .    |
 
-| Inputs                       | Value           | Unit        | Source   |
-| ---------------------------- | --------------- | ----------- | -------- |
-| passengers per year          | $5 \times 10^9$ | $year^{-1}$ | ATAG[^1] |
-| seats per aircraft           | $150$           | .           |          |
-| flights per aircraft per day | $2$             | $day^{-1}$  |          |
+| Inputs                       | Value           | Unit     | Source   |
+| ---------------------------- | --------------- | -------- | -------- |
+| passengers per year          | $5 \times 10^9$ | year^-1^ | ATAG[^1] |
+| seats per aircraft           | $150$           | .        |          |
+| flights per aircraft per day | $2$             | day^-1^  |          |
 
 ### Equations
 

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,20 @@
+window.MathJax = {
+    tex: {
+      inlineMath: [["\\(", "\\)"]],
+      displayMath: [["\\[", "\\]"]],
+      processEscapes: true,
+      processEnvironments: true,
+      tags: "ams",
+    },
+    options: {
+      ignoreHtmlClass: ".*|",
+      processHtmlClass: "arithmatex",
+    },
+  };
+  
+  document$.subscribe(() => {
+    MathJax.startup.output.clearCache();
+    MathJax.typesetClear();
+    MathJax.texReset();
+    MathJax.typesetPromise();
+  });

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,3 +5,11 @@ theme:
 nav:
   - index.md
   - aviation.md
+
+markdown_extensions:
+  - pymdownx.arithmatex:
+      generic: true
+
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,8 @@ nav:
   - aviation.md
 
 markdown_extensions:
+  - pymdownx.caret
+  - pymdownx.tilde
   - pymdownx.arithmatex:
       generic: true
 


### PR DESCRIPTION
This PR configures MathJax with mkdocs-material so that math in the documentation can be formatted more powerfully. The [MkDocs documention](https://squidfunk.github.io/mkdocs-material/reference/math/) discussed different options for displaying math in documentation. This configuration was copied verbatim with one exception. To enable equation numbering and referencing, additional MathJax configuration was required, which is explained in the [MathJax documentation](https://docs.mathjax.org/en/latest/input/tex/eqnumbers.html).