### PR TITLE
Add `transform` decorator

### DIFF
--- a/src/aviation/__init__.py
+++ b/src/aviation/__init__.py
@@ -1,5 +1,7 @@
 """A simple model of global aviation."""
 
-__all__ = ("passengers_per_day", "required_global_fleet")
+__all__ = ("passengers_per_day", "required_global_fleet", "transforms")
 
 from aviation.fleet import passengers_per_day, required_global_fleet
+
+transforms = (passengers_per_day, required_global_fleet)

--- a/src/aviation/_model.py
+++ b/src/aviation/_model.py
@@ -1,0 +1,22 @@
+"""Decorate functions as transforms."""
+
+__all__ = ("Transform", "transform")
+
+import collections.abc
+import inspect
+import typing
+
+
+class Transform[T, **P](typing.Protocol):
+    name: str
+    parameters: tuple[str, ...]
+
+    def __call__(*args: P.args, **kwargs: P.kwargs) -> T: ...
+
+
+def transform[T, **P](function: collections.abc.Callable[P, T]) -> Transform[T, P]:
+    """Decorator to identify functions as transforms."""
+    transform = typing.cast("Transform[T, P]", function)
+    transform.name = function.__name__
+    transform.parameters = tuple(inspect.signature(function).parameters.keys())
+    return transform

--- a/src/aviation/fleet.py
+++ b/src/aviation/fleet.py
@@ -1,6 +1,9 @@
 """Modelling of the global fleet based on average passenger and aircraft data."""
 
+from aviation import _model as model
 
+
+@model.transform
 def passengers_per_day(passengers_per_year: float, days_per_year: float) -> float:
     """The number of passengers per day globally.
 
@@ -11,6 +14,7 @@ def passengers_per_day(passengers_per_year: float, days_per_year: float) -> floa
     return passengers_per_year / days_per_year
 
 
+@model.transform
 def required_global_fleet(
     passengers_per_day: float, seats_per_aircraft: float, flights_per_aircraft_per_day: float
 ) -> float:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,11 @@
+from aviation._model import transform
+
+
+@transform
+def add(x: float, y: float) -> float:
+    return x + y
+
+
+def test_transform_decorator() -> None:
+    assert add.name == "add"
+    assert add.parameters == ("x", "y")


### PR DESCRIPTION
This PR implements the transform decorator, similar to the one in [camia-model](https://github.com/aviation-impact-accelerator/camia-model), which is used to annotate Python functions as transforms, adding additional attributes that are used to construct the transform [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph).