### PR TITLE
Add `SystemsModel` class

### DIFF
--- a/analysis/passengers_per_day.py
+++ b/analysis/passengers_per_day.py
@@ -1,11 +1,17 @@
 """Analysis to determine the number of passengers per day globally."""
 
 import aviation
+from aviation import _engine as engine
 
-days_per_year = 365.0
 passengers_per_year = 5_000_000_000.0
-seats_per_aircraft = 150.0
-flights_per_aircraft_per_day = 2.0
+days_per_year = 365.0
 
-passengers_per_day = aviation.passengers_per_day(passengers_per_year, days_per_year)
+inputs = {
+    "days_per_year": days_per_year,
+    "passengers_per_year": passengers_per_year,
+}
+output = "passengers_per_day"
+
+systems_model = engine.SystemsModel(aviation.transforms)
+passengers_per_day = systems_model.evaluate(inputs, output)
 print(f"{passengers_per_day=}")

--- a/analysis/required_global_fleet.py
+++ b/analysis/required_global_fleet.py
@@ -1,14 +1,21 @@
 """Analysis to determine the required size of the global fleet."""
 
 import aviation
+from aviation import _engine as engine
 
-days_per_year = 365.0
 passengers_per_year = 5_000_000_000.0
-seats_per_aircraft = 150.0
-flights_per_aircraft_per_day = 2.0
+days_per_year = 365.0
+seats_per_aircraft = 200.0
+flights_per_aircraft_per_day = 3.0
 
-passengers_per_day = aviation.passengers_per_day(passengers_per_year, days_per_year)
-required_global_fleet = aviation.required_global_fleet(
-    passengers_per_day, seats_per_aircraft, flights_per_aircraft_per_day
-)
+inputs = {
+    "passengers_per_year": passengers_per_year,
+    "days_per_year": days_per_year,
+    "seats_per_aircraft": seats_per_aircraft,
+    "flights_per_aircraft_per_day": flights_per_aircraft_per_day,
+}
+output = "required_global_fleet"
+
+systems_model = engine.SystemsModel(aviation.transforms)
+required_global_fleet = systems_model.evaluate(inputs, output)
 print(f"{required_global_fleet=}")

--- a/src/aviation/_engine.py
+++ b/src/aviation/_engine.py
@@ -1,0 +1,57 @@
+"""Evaluate systems model of transforms."""
+
+__all__ = ("SystemsModel",)
+
+import collections.abc
+import typing
+
+from aviation._model import Transform
+
+
+class SystemsModel:
+    """A systems model defined by a collection of transform."""
+
+    def __init__(self, transforms: collections.abc.Sequence[Transform[typing.Any, ...]]) -> None:
+        """Initialize the systems model from a collection of transforms."""
+        self.transforms = set(transforms)
+
+    def evaluate(self, inputs: dict[str, typing.Any], output: str) -> typing.Any:  # noqa: ANN401
+        """Calculate the value returned by a transform.
+
+        This implementation uses recursion to recursively evaluate the arguments required by a
+        transform if they aren't already known. The algorithm has four steps:
+        1. Check to see if the requested `output` is already a known member of `inputs`. If it is
+        then the value can be returned without the need for any computation.
+        2. Find the function who's name matches `output` as this is what needs to be evaluated in
+        this call. If no transform can be found with a matching name then it won't be possible to
+        continue evaluation and an error must be raised.
+        3. Build a mapping of the transform's parameters to the arguments that will be used to
+        evaluate the transform. If the value of the parameter isn't currently known then make a
+        recursive call to `self.evaluate` and insert the parameter name-value pair back into
+        `inputs` for its reuse later.
+        4. Evaluate the transform using the keyword arguments and return the value.
+        """
+        # If the requested `output` has already been supplied as an input then this can just be
+        # returned directly without any need for computation.
+        if output in inputs:
+            return inputs[output]
+
+        # The requested `output` isn't in `inputs` so it must be the name of a transform in
+        # `self.transforms`. If it's not found in `self.transforms` then there must be an error.
+        for transform in self.transforms:
+            if transform.name == output:
+                break
+        else:
+            message = f"Unknown transform: {output}"
+            raise ValueError(message)
+
+        # To evaluate the `transform`, arguments for all of its parameters are required. If a
+        # parameter's name can't be found in `inputs` make a recursive call to `self.evaluate` to
+        # evaluate it and then insert it into `inputs`.
+        for parameter in transform.parameters:
+            if parameter not in inputs:
+                inputs[parameter] = self.evaluate(inputs, parameter)
+
+        # Evaluate and return the `transform` associated with the passed `output`.
+        arguments = {parameter: inputs[parameter] for parameter in transform.parameters}
+        return transform(**arguments)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,49 @@
+import typing
+
+import pytest
+
+from aviation import transforms
+from aviation._engine import SystemsModel
+
+
+@pytest.fixture
+def systems_model() -> SystemsModel:
+    return SystemsModel(transforms)
+
+
+@pytest.mark.parametrize(
+    ("inputs", "output", "expected"),
+    [
+        (
+            {"passengers_per_year": 5_000_000_000.0, "days_per_year": 365.0},
+            "passengers_per_day",
+            13_698_630.0,
+        ),
+        (
+            {
+                "days_per_year": 365.0,
+                "passengers_per_year": 5_000_000_000.0,
+                "seats_per_aircraft": 200.0,
+                "flights_per_aircraft_per_day": 3.0,
+            },
+            "required_global_fleet",
+            22_831.0,
+        ),
+        (
+            {
+                "passengers_per_day": 13_698_630.0,
+                "seats_per_aircraft": 200.0,
+                "flights_per_aircraft_per_day": 3.0,
+            },
+            "required_global_fleet",
+            22_831.0,
+        ),
+    ],
+)
+def test_transform_evaluation(
+    systems_model: SystemsModel,
+    inputs: dict[str, typing.Any],
+    output: str,
+    expected: typing.Any,  # noqa: ANN401
+) -> None:
+    assert systems_model.evaluate(inputs, output) == pytest.approx(expected, abs=1.0)


### PR DESCRIPTION
This PR adds the `SystemsModel` class, like the one from [camia-engine](https://github.com/aviation-impact-accelerator/camia-engine), which can be used to define a systems model from transforms and used to evaluate a specific transform as an output from a collection of input transforms.