### PR TITLE
Use camia-model's unit system

### DIFF
--- a/analysis/passengers_per_day.py
+++ b/analysis/passengers_per_day.py
@@ -1,11 +1,13 @@
 """Analysis to determine the number of passengers per day globally."""
 
 import camia_engine as engine
+from camia_model.units import day, year
 
 import aviation
+from aviation.units import passenger
 
-passengers_per_year = 5_000_000_000.0
-days_per_year = 365.0
+passengers_per_year = 5_000_000_000.0 * passenger / year
+days_per_year = 365.0 * day / year
 
 inputs = {
     "days_per_year": days_per_year,

--- a/analysis/passengers_per_day.py
+++ b/analysis/passengers_per_day.py
@@ -1,16 +1,14 @@
 """Analysis to determine the number of passengers per day globally."""
 
 import camia_engine as engine
-from camia_model.units import day, year
+from camia_model.units import year
 
 import aviation
 from aviation.units import passenger
 
 passengers_per_year = 5_000_000_000.0 * passenger / year
-days_per_year = 365.0 * day / year
 
 inputs = {
-    "days_per_year": days_per_year,
     "passengers_per_year": passengers_per_year,
 }
 output = "passengers_per_day"

--- a/analysis/required_global_fleet.py
+++ b/analysis/required_global_fleet.py
@@ -7,13 +7,11 @@ import aviation
 from aviation.units import aircraft, journey, passenger
 
 passengers_per_year = 5_000_000_000.0 * passenger / year
-days_per_year = 365.0 * day / year
 seats_per_aircraft = 200.0 * passenger / aircraft
 flights_per_aircraft_per_day = 3.0 * journey / (aircraft * day)
 
 inputs = {
     "passengers_per_year": passengers_per_year,
-    "days_per_year": days_per_year,
     "seats_per_aircraft": seats_per_aircraft,
     "flights_per_aircraft_per_day": flights_per_aircraft_per_day,
 }

--- a/analysis/required_global_fleet.py
+++ b/analysis/required_global_fleet.py
@@ -1,13 +1,15 @@
 """Analysis to determine the required size of the global fleet."""
 
 import camia_engine as engine
+from camia_model.units import day, year
 
 import aviation
+from aviation.units import aircraft, journey, passenger
 
-passengers_per_year = 5_000_000_000.0
-days_per_year = 365.0
-seats_per_aircraft = 200.0
-flights_per_aircraft_per_day = 3.0
+passengers_per_year = 5_000_000_000.0 * passenger / year
+days_per_year = 365.0 * day / year
+seats_per_aircraft = 200.0 * passenger / aircraft
+flights_per_aircraft_per_day = 3.0 * journey / (aircraft * day)
 
 inputs = {
     "passengers_per_year": passengers_per_year,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dev = [
     "mypy>=1.18.2",
     "pre-commit>=4.3.0",
     "pytest>=8.4.2",
+    "pytest-camia>=0.3.4",
     "ruff>=0.13.0",
 ]
 docs = [

--- a/src/aviation/fleet.py
+++ b/src/aviation/fleet.py
@@ -1,10 +1,20 @@
 """Modelling of the global fleet based on average passenger and aircraft data."""
 
+__all__ = ("passengers_per_day", "required_global_fleet")
+
+import typing
+
 import camia_model as model
+from camia_model.units import Quantity, day, year
+
+from aviation.units import aircraft, journey, passenger
 
 
 @model.transform
-def passengers_per_day(passengers_per_year: float, days_per_year: float) -> float:
+def passengers_per_day(
+    passengers_per_year: typing.Annotated[Quantity, passenger / year],
+    days_per_year: typing.Annotated[Quantity, day / year],
+) -> typing.Annotated[Quantity, passenger / day]:
     """The number of passengers per day globally.
 
     Args:
@@ -16,8 +26,10 @@ def passengers_per_day(passengers_per_year: float, days_per_year: float) -> floa
 
 @model.transform
 def required_global_fleet(
-    passengers_per_day: float, seats_per_aircraft: float, flights_per_aircraft_per_day: float
-) -> float:
+    passengers_per_day: typing.Annotated[Quantity, passenger / day],
+    seats_per_aircraft: typing.Annotated[Quantity, passenger / aircraft],
+    flights_per_aircraft_per_day: typing.Annotated[Quantity, journey / (aircraft * day)],
+) -> typing.Annotated[Quantity, aircraft]:
     """The size of the required global fleet.
 
     Args:
@@ -26,4 +38,7 @@ def required_global_fleet(
         flights_per_aircraft_per_day: The average number of flights a commercial aircraft makes on
             average per day.
     """
-    return passengers_per_day / (seats_per_aircraft * flights_per_aircraft_per_day)
+    aircraft_per_journey = 1.0 * aircraft / journey
+    return passengers_per_day / (
+        seats_per_aircraft * flights_per_aircraft_per_day * aircraft_per_journey
+    )

--- a/src/aviation/fleet.py
+++ b/src/aviation/fleet.py
@@ -13,15 +13,13 @@ from aviation.units import aircraft, journey, passenger
 @model.transform
 def passengers_per_day(
     passengers_per_year: typing.Annotated[Quantity, passenger / year],
-    days_per_year: typing.Annotated[Quantity, day / year],
 ) -> typing.Annotated[Quantity, passenger / day]:
     """The number of passengers per day globally.
 
     Args:
         passengers_per_year: The number of passengers flying per year globally.
-        days_per_year: The number of days in the modelled year.
     """
-    return passengers_per_year / days_per_year
+    return passengers_per_year.convert_to(passenger / day)
 
 
 @model.transform

--- a/src/aviation/units.py
+++ b/src/aviation/units.py
@@ -1,0 +1,9 @@
+"""Additional units to support accurate unit annotations of transforms."""
+
+__all__ = ("aircraft", "journey", "passenger")
+
+import camia_model as model
+
+aircraft = model.units.Unit.new_named("aircraft", relation=model.units.DIMENSIONLESS)
+journey = model.units.Unit.new_named("journey", relation=model.units.DIMENSIONLESS)
+passenger = model.units.Unit.new_named("passenger", relation=model.units.DIMENSIONLESS)

--- a/tests/test_aviation.py
+++ b/tests/test_aviation.py
@@ -1,35 +1,42 @@
+import typing
+
 import pytest
+import pytest_camia
+from camia_model.units import Quantity, day, year
 
 from aviation.fleet import passengers_per_day, required_global_fleet
+from aviation.units import aircraft, journey, passenger
 
 
 @pytest.mark.parametrize(
     ("passengers_per_year", "days_per_year", "expected_passengers_per_day"),
     [
-        (365_000_000.0, 365.0, 1_000_000.0),
-        (365_250_000.0, 365.25, 1_000_000.0),
-        (366_000_000.0, 366.0, 1_000_000.0),
-        (5_000_000_000.0, 365.0, 13_698_630.0),
+        (365_000_000.0 * passenger / year, 365.0 * day / year, 1_000_000.0 * passenger / day),
+        (365_250_000.0 * passenger / year, 365.25 * day / year, 1_000_000.0 * passenger / day),
+        (366_000_000.0 * passenger / year, 366.0 * day / year, 1_000_000.0 * passenger / day),
+        (5_000_000_000.0 * passenger / year, 365.0 * day / year, 13_698_630.0 * passenger / day),
     ],
 )
 def test_passengers_per_day(
-    passengers_per_year: float, days_per_year: float, expected_passengers_per_day: float
+    passengers_per_year: typing.Annotated[Quantity, passenger / year],
+    days_per_year: typing.Annotated[Quantity, day / year],
+    expected_passengers_per_day: typing.Annotated[Quantity, passenger / day],
 ) -> None:
     result = passengers_per_day(passengers_per_year, days_per_year)
-    assert result == pytest.approx(expected_passengers_per_day)
+    assert result == pytest_camia.approx(expected_passengers_per_day)
 
 
 def test_required_global_fleet() -> None:
-    days_per_year = 365.0
-    passengers_per_year = 5_000_000_000.0
-    seats_per_aircraft = 160.0
-    flights_per_aircraft_per_day = 2.5
+    passengers_per_year = 5_000_000_000.0 * passenger / year
+    days_per_year = 365.0 * day / year
+    seats_per_aircraft = 200.0 * passenger / aircraft
+    flights_per_aircraft_per_day = 3.0 * journey / (aircraft * day)
 
-    expected_required_global_fleet = 25_000.0
+    expected_required_global_fleet = 25_000.0 * aircraft
 
     result = required_global_fleet(
         passengers_per_day(passengers_per_year, days_per_year),
         seats_per_aircraft,
         flights_per_aircraft_per_day,
     )
-    assert result == pytest.approx(expected_required_global_fleet, abs=10_000.0)
+    assert result == pytest_camia.approx(expected_required_global_fleet, atol=10_000.0)

--- a/tests/test_aviation.py
+++ b/tests/test_aviation.py
@@ -9,33 +9,29 @@ from aviation.units import aircraft, journey, passenger
 
 
 @pytest.mark.parametrize(
-    ("passengers_per_year", "days_per_year", "expected_passengers_per_day"),
+    ("passengers_per_year", "expected_passengers_per_day"),
     [
-        (365_000_000.0 * passenger / year, 365.0 * day / year, 1_000_000.0 * passenger / day),
-        (365_250_000.0 * passenger / year, 365.25 * day / year, 1_000_000.0 * passenger / day),
-        (366_000_000.0 * passenger / year, 366.0 * day / year, 1_000_000.0 * passenger / day),
-        (5_000_000_000.0 * passenger / year, 365.0 * day / year, 13_698_630.0 * passenger / day),
+        (365_250_000.0 * passenger / year, 1_000_000.0 * passenger / day),
+        (5_000_000_000.0 * passenger / year, 13_689_254.0 * passenger / day),
     ],
 )
 def test_passengers_per_day(
     passengers_per_year: typing.Annotated[Quantity, passenger / year],
-    days_per_year: typing.Annotated[Quantity, day / year],
     expected_passengers_per_day: typing.Annotated[Quantity, passenger / day],
 ) -> None:
-    result = passengers_per_day(passengers_per_year, days_per_year)
+    result = passengers_per_day(passengers_per_year)
     assert result == pytest_camia.approx(expected_passengers_per_day)
 
 
 def test_required_global_fleet() -> None:
     passengers_per_year = 5_000_000_000.0 * passenger / year
-    days_per_year = 365.0 * day / year
     seats_per_aircraft = 200.0 * passenger / aircraft
     flights_per_aircraft_per_day = 3.0 * journey / (aircraft * day)
 
     expected_required_global_fleet = 25_000.0 * aircraft
 
     result = required_global_fleet(
-        passengers_per_day(passengers_per_year, days_per_year),
+        passengers_per_day(passengers_per_year),
         seats_per_aircraft,
         flights_per_aircraft_per_day,
     )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,8 +2,11 @@ import typing
 
 import camia_engine as engine
 import pytest
+import pytest_camia
+from camia_model.units import day, year
 
 from aviation import transforms
+from aviation.units import aircraft, journey, passenger
 
 
 @pytest.fixture
@@ -15,28 +18,31 @@ def systems_model() -> engine.SystemsModel:
     ("inputs", "output", "expected"),
     [
         (
-            {"passengers_per_year": 5_000_000_000.0, "days_per_year": 365.0},
+            {
+                "passengers_per_year": 5_000_000_000.0 * passenger / year,
+                "days_per_year": 365.0 * day / year,
+            },
             "passengers_per_day",
-            13_698_630.0,
+            13_698_630.0 * passenger / day,
         ),
         (
             {
-                "days_per_year": 365.0,
-                "passengers_per_year": 5_000_000_000.0,
-                "seats_per_aircraft": 200.0,
-                "flights_per_aircraft_per_day": 3.0,
+                "passengers_per_year": 5_000_000_000.0 * passenger / year,
+                "days_per_year": 365.0 * day / year,
+                "seats_per_aircraft": 200.0 * passenger / aircraft,
+                "flights_per_aircraft_per_day": 3.0 * journey / (aircraft * day),
             },
             "required_global_fleet",
-            22_831.0,
+            22_831.0 * aircraft,
         ),
         (
             {
-                "passengers_per_day": 13_698_630.0,
-                "seats_per_aircraft": 200.0,
-                "flights_per_aircraft_per_day": 3.0,
+                "passengers_per_day": 13_698_630.0 * passenger / day,
+                "seats_per_aircraft": 200.0 * passenger / aircraft,
+                "flights_per_aircraft_per_day": 3.0 * journey / (aircraft * day),
             },
             "required_global_fleet",
-            22_831.0,
+            22_831.0 * aircraft,
         ),
     ],
 )
@@ -46,4 +52,4 @@ def test_transform_evaluation(
     output: str,
     expected: typing.Any,  # noqa: ANN401
 ) -> None:
-    assert systems_model.evaluate(inputs, output) == pytest.approx(expected, abs=1.0)
+    assert systems_model.evaluate(inputs, output) == pytest_camia.approx(expected, atol=1.0)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -20,29 +20,27 @@ def systems_model() -> engine.SystemsModel:
         (
             {
                 "passengers_per_year": 5_000_000_000.0 * passenger / year,
-                "days_per_year": 365.0 * day / year,
             },
             "passengers_per_day",
-            13_698_630.0 * passenger / day,
+            13_689_254.0 * passenger / day,
         ),
         (
             {
                 "passengers_per_year": 5_000_000_000.0 * passenger / year,
-                "days_per_year": 365.0 * day / year,
                 "seats_per_aircraft": 200.0 * passenger / aircraft,
                 "flights_per_aircraft_per_day": 3.0 * journey / (aircraft * day),
             },
             "required_global_fleet",
-            22_831.0 * aircraft,
+            22_815.0 * aircraft,
         ),
         (
             {
-                "passengers_per_day": 13_698_630.0 * passenger / day,
+                "passengers_per_day": 13_689_254.0 * passenger / day,
                 "seats_per_aircraft": 200.0 * passenger / aircraft,
                 "flights_per_aircraft_per_day": 3.0 * journey / (aircraft * day),
             },
             "required_global_fleet",
-            22_831.0 * aircraft,
+            22_815.0 * aircraft,
         ),
     ],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-camia" },
     { name = "ruff" },
 ]
 docs = [
@@ -36,6 +37,7 @@ dev = [
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-camia", specifier = ">=0.3.4" },
     { name = "ruff", specifier = ">=0.13.0" },
 ]
 docs = [
@@ -739,6 +741,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest-camia"
+version = "0.3.4"
+source = { registry = "https://gitlab.developers.cam.ac.uk/api/v4/projects/8115/packages/pypi/simple" }
+dependencies = [
+    { name = "camia-model" },
+    { name = "pytest" },
+]
+sdist = { url = "https://gitlab.developers.cam.ac.uk/api/v4/projects/8115/packages/pypi/files/516111aa31ba394d0b19c8aef5bab0250153c27e5f5e292675815a7ae7bfe4c7/pytest_camia-0.3.4.tar.gz", hash = "sha256:516111aa31ba394d0b19c8aef5bab0250153c27e5f5e292675815a7ae7bfe4c7" }
+wheels = [
+    { url = "https://gitlab.developers.cam.ac.uk/api/v4/projects/8115/packages/pypi/files/aba7f3b2f0fd09b786ed3a29905273cebdc4ab5626001463546f3afee52ae407/pytest_camia-0.3.4-py3-none-any.whl", hash = "sha256:aba7f3b2f0fd09b786ed3a29905273cebdc4ab5626001463546f3afee52ae407" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR refactors the repository to use [camia-model's units system](https://github.com/aviation-impact-accelerator/camia-model/tree/main/src/camia_model/units). It adds custom units for `aircraft`, `journey`, and `passenger` to showcase how these can be added and mixed with existing named units implemented in camia-model. It also showcases how to use camia-model's unit conversion (via `Quantity.convert_to(...)`) to convert a quantity with one unit to another unit with consistent dimensionality.

It also adds the AIA's [pytest-camia](https://github.com/aviation-impact-accelerator/pytest-camia) to the `dev` dependency group so that it can be used in tests to compare approximate equality for `Quantity` instances and to run automated units checking tests on all transforms in the `src/` directory.